### PR TITLE
Fixes to windows executable

### DIFF
--- a/.github/workflows/publish_and_release.yaml
+++ b/.github/workflows/publish_and_release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+  # Example on how to trigger this workflow manually:
+  # gh workflow run publish_and_release.yaml --field tag=v1.0.11-test --ref=fix-win-exec
+  # Where `v1.0.11-test` is the tag to use, and `fix-win-exec` is the branch to use (optional).
   workflow_dispatch:
     inputs:
       tag:

--- a/executable/fairsenseai-mac.spec
+++ b/executable/fairsenseai-mac.spec
@@ -5,6 +5,8 @@ datas = []
 datas += collect_data_files('gradio')
 datas += collect_data_files('gradio_client')
 datas += collect_data_files('safehttpx')
+datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energ
+y_mix.json")]
 datas.append(('../fairsenseai/ui', 'fairsenseai/ui'))
 datas.append(('../fairsenseai/dataframes_and_indexes', 'fairsenseai/dataframes_and_indexes'))
 

--- a/executable/fairsenseai-mac.spec
+++ b/executable/fairsenseai-mac.spec
@@ -5,8 +5,7 @@ datas = []
 datas += collect_data_files('gradio')
 datas += collect_data_files('gradio_client')
 datas += collect_data_files('safehttpx')
-datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energ
-y_mix.json")]
+datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energy_mix.json")]
 datas.append(('../fairsenseai/ui', 'fairsenseai/ui'))
 datas.append(('../fairsenseai/dataframes_and_indexes', 'fairsenseai/dataframes_and_indexes'))
 

--- a/executable/fairsenseai-win+linux.spec
+++ b/executable/fairsenseai-win+linux.spec
@@ -5,6 +5,8 @@ datas = []
 datas += collect_data_files('gradio')
 datas += collect_data_files('gradio_client')
 datas += collect_data_files('safehttpx')
+datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energ
+y_mix.json")]
 datas.append(('../fairsenseai/ui', 'fairsenseai/ui'))
 datas.append(('../fairsenseai/dataframes_and_indexes', 'fairsenseai/dataframes_and_indexes'))
 

--- a/executable/fairsenseai-win+linux.spec
+++ b/executable/fairsenseai-win+linux.spec
@@ -5,8 +5,7 @@ datas = []
 datas += collect_data_files('gradio')
 datas += collect_data_files('gradio_client')
 datas += collect_data_files('safehttpx')
-datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energ
-y_mix.json")]
+datas += [(src, dst) for src, dst in collect_data_files("codecarbon") if src.endswith("global_energy_mix.json")]
 datas.append(('../fairsenseai/ui', 'fairsenseai/ui'))
 datas.append(('../fairsenseai/dataframes_and_indexes', 'fairsenseai/dataframes_and_indexes'))
 

--- a/fairsenseai/app.py
+++ b/fairsenseai/app.py
@@ -49,13 +49,13 @@ def start_server(
     script_dir = Path(__file__).resolve().parent
     ui_dir = script_dir / "ui"
 
-    with open(ui_dir / "home.html") as home_file:
+    with open(ui_dir / "home.html", encoding="utf-8") as home_file:
         home = home_file.read()
 
-    with open(ui_dir / "footer.html") as footer_file:
+    with open(ui_dir / "footer.html", encoding="utf-8") as footer_file:
         footer = footer_file.read()
 
-    with open(ui_dir / "about.html") as page_file:
+    with open(ui_dir / "about.html", encoding="utf-8") as page_file:
         about = page_file.read()
 
     demo = gr.Blocks()

--- a/fairsenseai/runtime.py
+++ b/fairsenseai/runtime.py
@@ -56,6 +56,9 @@ class FairsenseRuntime(object):
             self.add_allowed_path(self.emissions_output_dir)
 
         else:
+            self.bias_default_directory = None
+            self.risk_default_directory = None
+            self.emissions_output_dir = "."
             print("Starting FairsenseRuntime without file system access.")
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -257,6 +260,11 @@ class FairsenseGPURuntime(FairsenseRuntime):
             project_name="fairsense-gpu-inference", 
             output_dir=self.emissions_output_dir,
         )
+
+        if not self.allow_filesystem_access:
+            # TODO: This is a hack to prevent the tracker from saving to file when filesystem access is disabled
+            # They should come up with a better solution for this
+            tracker.save_to_file = False
         
         tracker.start()
         try:
@@ -366,7 +374,12 @@ class FairsenseCPURuntime(FairsenseRuntime):
             project_name="fairsense-cpu-inference", 
             output_dir=self.emissions_output_dir,
         )
-        
+
+        if not self.allow_filesystem_access:
+            # TODO: This is a hack to prevent the tracker from saving to file when filesystem access is disabled
+            # They should come up with a better solution for this
+            tracker.save_to_file = False
+
         tracker.start()
         try:
             if progress:


### PR DESCRIPTION
Adding a few fixes to make the windows executable work:
- Adding static files from `codecarbon` to the build
- Specifying the encoding in the UI files we read manually so it works on all systems
- Making sure `codecarbon` does not attemp to write to the filesystem

Tested with a local windows machine and the build produced by github actions works without issues.